### PR TITLE
Use Poetry for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM python:3.8-slim
+FROM python:3.11-slim
 
 # Set the working directory
 WORKDIR /usr/src/app
 
-# Copy the requirements file and install dependencies
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+# Install Poetry
+RUN pip install --no-cache-dir poetry
+
+# Copy dependency files and install
+COPY pyproject.toml poetry.lock* ./
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-interaction --no-ansi
 
 # Copy the rest of the application code
 COPY . .


### PR DESCRIPTION
## Summary
- update Dockerfile to use `python:3.11-slim`
- install Poetry and run `poetry install`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840c39914408322a477a35636aa5964