### PR TITLE
Update README for Docker Compose usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,34 @@
 This project provides a crawler and a simple Gradio interface for querying indexed content.
 
 Copy `src/.env.example` to `src/.env` and fill in your API credentials before running the application.
+
+## Environment variables
+
+The application reads the following variables from `src/.env`:
+
+```bash
+OPENAI_API_KEY=your-openai-api-key
+PINECONE_API_KEY=your-pinecone-api-key
+```
+
+These credentials are required by both the crawler and the Gradio UI.
+
+## Running the crawler and indexer
+
+You can run the crawler and build the Pinecone index using Docker Compose:
+
+```bash
+docker compose run --rm indexer
+```
+
+This command fetches the website content, converts it to Markdown and uploads the chunks to the configured Pinecone index.
+
+## Starting the Gradio UI
+
+Launch the chatbot interface with Docker Compose:
+
+```bash
+docker compose up chatbot
+```
+
+The UI will be available at [http://localhost:5000](http://localhost:5000).


### PR DESCRIPTION
## Summary
- document required environment variables
- add steps to run the crawler/indexer with Docker Compose
- add instructions for starting the Gradio UI with Docker Compose

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843421022cc8322996546c8342e9362